### PR TITLE
Add plain Ray Serve serverless inference example

### DIFF
--- a/docs/stable/deployment/ray_serve_plain.md
+++ b/docs/stable/deployment/ray_serve_plain.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 4
+---
+
+# Plain Ray Serve Deployment (No Store Optimizations)
+
+This guide walks through deploying a plain large-language-model inference service
+on Ray Serve without ServerlessLLM's accelerated checkpoint loader. It pairs with
+the [Ray serverless example](../../../examples/ray_serverless/README.md), which
+contains the deployment script and step-by-step instructions.
+
+## When to Use This Setup
+
+- You want to benchmark baseline Ray Serve performance before enabling
+  ServerlessLLM optimizations.
+- Your platform cannot mount the ServerlessLLM store or you prefer to rely on the
+  Hugging Face cache built into `transformers`.
+- You need a minimal reference for running Ray Serve with autoscaling to zero.
+
+## Overview
+
+The example exposes a FastAPI app via Ray Serve with the following traits:
+
+- **Model loading** uses `transformers.AutoModelForCausalLM.from_pretrained`
+  directly, so the first activation downloads weights from the Hugging Face Hub
+  (or a pre-populated cache).
+- **Autoscaling** is configured via Serve's `autoscaling_config`. Replicas scale
+  between zero and `MAX_REPLICAS` depending on request concurrency.
+- **Serverless-friendly**: Environment variables allow you to request GPU or CPU
+  resources per replica and to tune the autoscaler targets.
+
+## Prerequisites
+
+Install Ray Serve, PyTorch, and Transformers. For example:
+
+```bash
+pip install "ray[serve]>=2.10.0" torch transformers fastapi uvicorn
+```
+
+Ensure the dependencies are present on all Ray nodes that might host Serve
+replicas.
+
+## Deployment Steps
+
+1. **Launch a Ray cluster.** For local tests, run:
+   ```bash
+   ray start --head --dashboard-host=0.0.0.0 --num-cpus=4
+   ```
+   Connect additional nodes with `ray start --address='ray://<HEAD_IP>:10001'` or
+   follow your managed platform's instructions.
+
+2. **Configure the deployment.** Override environment variables such as
+   `MODEL_ID`, `NUM_GPUS_PER_REPLICA`, and `MAX_REPLICAS` to match your hardware
+   and workload targets. The full list is documented in the
+   [example README](../../../examples/ray_serverless/README.md#2-configure-the-deployment).
+
+3. **Deploy the Serve graph.** From the repository root run:
+   ```bash
+   serve run examples/ray_serverless/ray_serve_app:deployment_graph
+   ```
+   Serve uploads the deployment to the cluster and spins up replicas on demand.
+
+4. **Send requests.** POST to `/generate` with a `prompt` or `prompts` field, or
+   call `/healthz` to verify the deployment is live. Refer to the example README
+   for `curl` samples.
+
+5. **Monitor and scale.** Use the Ray Dashboard or `ray list actors` to observe
+   replica creation. Tune `TARGET_ONGOING_REQUESTS` and `MAX_REPLICAS` for
+   desired throughput.
+
+6. **Clean up.** When finished, remove the deployment with
+   `serve delete RayServeLLM` and stop the cluster via `ray stop`.
+
+Because this configuration intentionally bypasses the ServerlessLLM store, it is
+ideal for comparing against the optimized pipeline or for environments where a
+shared checkpoint store cannot be attached.

--- a/examples/ray_serverless/README.md
+++ b/examples/ray_serverless/README.md
@@ -1,0 +1,154 @@
+# Plain Ray-based LLM Inference on a Serverless Platform
+
+This example shows how to run a **plain Ray Serve application** for large language
+model inference on a serverless platform. Unlike the default ServerlessLLM flow,
+this setup does **not** rely on the optimized checkpoint loading path – models are
+loaded directly from the Hugging Face Hub cache when a replica starts. The focus
+here is demonstrating how to combine Ray's autoscaling primitives with a minimal
+FastAPI interface for on-demand inference.
+
+The application code lives in [`ray_serve_app.py`](./ray_serve_app.py) and can be
+deployed with `serve run`. Autoscaling is configured so that replicas can scale
+all the way down to zero when there is no traffic, keeping GPU time usage to the
+bare minimum.
+
+## Prerequisites
+
+- Python 3.10 or newer
+- [Ray 2.10+](https://docs.ray.io/en/latest/) with the Serve extras installed
+- PyTorch and Transformers (any build that supports the target hardware)
+- Optional: at least one NVIDIA GPU for accelerated inference
+
+Install the dependencies into a clean environment:
+
+```bash
+pip install "ray[serve]>=2.10.0" torch transformers fastapi uvicorn
+```
+
+If you plan to run the workload on a remote Ray cluster or a managed serverless
+platform, make sure the dependencies are available on every node that will host
+Serve replicas.
+
+## 1. Start a Ray Cluster
+
+For a quick local setup, launch a Ray head node:
+
+```bash
+ray start --head --dashboard-host=0.0.0.0 --num-cpus=4
+```
+
+If you have additional worker nodes or GPU machines, connect them to the head
+with:
+
+```bash
+ray start --address='ray://<HEAD_IP>:10001'
+```
+
+> **Note:** For real serverless deployments (e.g., KubeRay, Anyscale), use the
+> platform's provisioning workflow and make sure the Serve controller can reach
+the `ray start --head` instance.
+
+## 2. Configure the Deployment
+
+The Serve deployment reads configuration from environment variables:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `MODEL_ID` | `facebook/opt-125m` | Hugging Face model identifier to load. |
+| `MAX_NEW_TOKENS` | `256` | Maximum tokens generated per request. |
+| `TEMPERATURE` | `0.7` | Sampling temperature. Set to `0` for greedy decoding. |
+| `TOP_P` | `0.9` | Nucleus sampling `top_p`. |
+| `NUM_GPUS_PER_REPLICA` | `0.0` | GPUs requested by each replica. Set to `1` on GPU nodes. |
+| `NUM_CPUS_PER_REPLICA` | `1.0` | CPUs requested per replica. |
+| `MIN_REPLICAS` | `0` | Minimum number of active replicas. |
+| `MAX_REPLICAS` | `2` | Maximum number of replicas Serve can scale out to. |
+| `TARGET_ONGOING_REQUESTS` | `1.0` | Target ongoing requests per replica used by autoscaling. |
+| `RAY_SERVE_AUTOSCALER_IDLE_TIMEOUT_S` | `60` | (Ray setting) Seconds of idleness before scaling a replica down. |
+
+Export any overrides before launching the deployment. For example, to use a GPU
+worker with a larger model:
+
+```bash
+export MODEL_ID=mistralai/Mistral-7B-Instruct-v0.2
+export NUM_GPUS_PER_REPLICA=1
+export MAX_REPLICAS=3
+export RAY_SERVE_AUTOSCALER_IDLE_TIMEOUT_S=120
+```
+
+## 3. Deploy the Application
+
+With the cluster running and the environment configured, deploy the Serve graph:
+
+```bash
+serve run examples/ray_serverless/ray_serve_app:deployment_graph
+```
+
+The command packages the deployment definition, uploads it to the Ray cluster,
+and waits for the first replica to become ready. Because `MIN_REPLICAS` defaults
+to zero, Serve will create a replica on demand when the first request arrives.
+
+> The first request for a new replica downloads the model from the Hugging Face
+> Hub (or reads from the local cache), which can take a few minutes for large
+> checkpoints. Subsequent activations reuse the cached weights.
+
+## 4. Send Inference Requests
+
+The deployment exposes two endpoints:
+
+- `GET /healthz` – health probe returning the model ID.
+- `POST /generate` – accepts a JSON payload with either a `prompt` or `prompts`
+  field.
+
+Example request:
+
+```bash
+curl http://127.0.0.1:8000/generate \
+  -H "Content-Type: application/json" \
+  -d '{
+        "prompt": "Write a haiku about Ray Serve.",
+        "generation_kwargs": {
+            "max_new_tokens": 64,
+            "temperature": 0.6,
+            "top_p": 0.95
+        }
+      }'
+```
+
+The response looks like:
+
+```json
+{
+  "model": "facebook/opt-125m",
+  "prompts": ["Write a haiku about Ray Serve."],
+  "completions": ["Scheduling waves flow\nAutoscaling moonlit pods\nServerless whispers"],
+  "generation_kwargs": {
+    "max_new_tokens": 64,
+    "temperature": 0.6,
+    "top_p": 0.95
+  }
+}
+```
+
+When there is no traffic, replicas scale down automatically after the idle
+timeout. The next request will spin up a fresh replica and reload the checkpoint
+straight from the Hugging Face cache.
+
+## 5. Observability and Scaling Behavior
+
+- Inspect autoscaling decisions with `ray dashboard` or `ray list actors`.
+- Adjust `TARGET_ONGOING_REQUESTS` to increase or decrease parallelism per
+  replica.
+- Tune `MAX_REPLICAS` to limit the maximum hardware footprint.
+
+## 6. Tear Down
+
+Shut down the Serve application and Ray cluster when you are done:
+
+```bash
+serve delete RayServeLLM
+ray stop
+```
+
+Because this walkthrough avoids the ServerlessLLM store, it is a good reference
+for benchmarking raw Ray Serve behavior or running on platforms where attaching
+an external checkpoint store is not possible.

--- a/examples/ray_serverless/ray_serve_app.py
+++ b/examples/ray_serverless/ray_serve_app.py
@@ -1,0 +1,168 @@
+# ---------------------------------------------------------------------------- #
+#  serverlessllm                                                               #
+#  copyright (c) serverlessllm team 2024                                       #
+#                                                                              #
+#  licensed under the apache license, version 2.0 (the "license");             #
+#  you may not use this file except in compliance with the license.            #
+#                                                                              #
+#  you may obtain a copy of the license at                                     #
+#                                                                              #
+#                  http://www.apache.org/licenses/license-2.0                  #
+#                                                                              #
+#  unless required by applicable law or agreed to in writing, software         #
+#  distributed under the license is distributed on an "as is" basis,           #
+#  without warranties or conditions of any kind, either express or implied.    #
+#  see the license for the specific language governing permissions and         #
+#  limitations under the license.                                              #
+# ---------------------------------------------------------------------------- #
+"""Minimal Ray Serve application for running LLM inference in a serverless way.
+
+This example demonstrates how to deploy a plain LLM workload on a Ray cluster
+without relying on the ServerlessLLM checkpoint store optimizations. It uses
+Ray Serve's autoscaling capabilities to scale replicas up and down based on the
+incoming request volume.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Iterable, List
+
+import torch
+from fastapi import FastAPI, Request
+from ray import serve
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+app = FastAPI()
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except ValueError:
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except ValueError:
+        return default
+
+
+def _normalize_completions(prompts: Iterable[str], outputs: List[str]) -> List[str]:
+    normalized: List[str] = []
+    for prompt, text in zip(prompts, outputs):
+        if text.startswith(prompt):
+            normalized.append(text[len(prompt) :].lstrip())
+        else:
+            normalized.append(text)
+    return normalized
+
+
+MIN_REPLICAS = _env_int("MIN_REPLICAS", 0)
+MAX_REPLICAS = _env_int("MAX_REPLICAS", 2)
+TARGET_ONGOING_REQUESTS = _env_float(
+    "TARGET_ONGOING_REQUESTS", 1.0
+)
+NUM_GPUS_PER_REPLICA = _env_float("NUM_GPUS_PER_REPLICA", 0.0)
+NUM_CPUS_PER_REPLICA = _env_float("NUM_CPUS_PER_REPLICA", 1.0)
+
+
+@serve.deployment(
+    autoscaling_config={
+        "min_replicas": MIN_REPLICAS,
+        "initial_replicas": MIN_REPLICAS,
+        "max_replicas": max(MIN_REPLICAS, MAX_REPLICAS),
+        "target_num_ongoing_requests_per_replica": max(TARGET_ONGOING_REQUESTS, 0.1),
+    },
+    ray_actor_options={
+        "num_gpus": NUM_GPUS_PER_REPLICA,
+        "num_cpus": NUM_CPUS_PER_REPLICA,
+    },
+)
+@serve.ingress(app)
+class RayServeLLM:
+    """A minimal Ray Serve deployment hosting a Hugging Face model."""
+
+    def __init__(self) -> None:
+        self.model_id = os.getenv("MODEL_ID", "facebook/opt-125m")
+        self.max_new_tokens = _env_int("MAX_NEW_TOKENS", 256)
+        self.temperature = float(os.getenv("TEMPERATURE", "0.7"))
+        self.top_p = float(os.getenv("TOP_P", "0.9"))
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        torch_dtype = (
+            torch.float16 if self.device == "cuda" else torch.float32
+        )
+
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_id)
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+
+        self.model = AutoModelForCausalLM.from_pretrained(
+            self.model_id,
+            torch_dtype=torch_dtype,
+            device_map="auto" if self.device == "cuda" else None,
+        )
+        if self.device == "cuda":
+            self.model.to(self.device)
+        self.model.eval()
+
+    @app.get("/healthz")
+    async def health(self) -> Dict[str, str]:
+        return {"status": "ok", "model": self.model_id}
+
+    @app.post("/generate")
+    async def generate(self, request: Request) -> Dict[str, Any]:
+        payload = await request.json()
+        prompts: Iterable[str]
+        if "prompts" in payload:
+            prompts = payload["prompts"]
+        elif "prompt" in payload:
+            prompts = [payload["prompt"]]
+        else:
+            return {"error": "Request payload must include 'prompt' or 'prompts'."}
+
+        prompts = [str(p) for p in prompts]
+        generation_kwargs = payload.get("generation_kwargs", {})
+        max_new_tokens = int(
+            generation_kwargs.get("max_new_tokens", self.max_new_tokens)
+        )
+        temperature = float(generation_kwargs.get("temperature", self.temperature))
+        top_p = float(generation_kwargs.get("top_p", self.top_p))
+
+        tokens = self.tokenizer(
+            prompts,
+            return_tensors="pt",
+            padding=True,
+        )
+        if self.device == "cuda":
+            tokens = {k: v.to(self.device) for k, v in tokens.items()}
+
+        with torch.inference_mode():
+            generated = self.model.generate(
+                **tokens,
+                max_new_tokens=max_new_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                do_sample=temperature > 0,
+                pad_token_id=self.tokenizer.eos_token_id,
+            )
+
+        decoded = self.tokenizer.batch_decode(
+            generated, skip_special_tokens=True
+        )
+        completions = _normalize_completions(prompts, decoded)
+        return {
+            "model": self.model_id,
+            "prompts": list(prompts),
+            "completions": completions,
+            "generation_kwargs": {
+                "max_new_tokens": max_new_tokens,
+                "temperature": temperature,
+                "top_p": top_p,
+            },
+        }
+
+
+deployment_graph = RayServeLLM.bind()
+


### PR DESCRIPTION
## Summary
- add a Ray Serve example that demonstrates a plain serverless LLM deployment without ServerlessLLM store optimizations
- document the workflow in both the example README and a deployment guide entry in the docs site

## Testing
- python -m compileall examples/ray_serverless/ray_serve_app.py

------
https://chatgpt.com/codex/tasks/task_b_68dff8fdb9fc832dbc888f3e96136849